### PR TITLE
fcp: properly set the partition actual size in write operations

### DIFF
--- a/fcp/src/cmd_write.c
+++ b/fcp/src/cmd_write.c
@@ -126,17 +126,15 @@ static int __write(args_t * args, off_t offset, entry_list_t * done_list)
 		return -1;
 	}
 
-	if (entry.actual < st.st_size) {
-		if (__ffs_entry_truncate(ffs, full_name,
-					 st.st_size) < 0) {
-			ERRNO(errno);
-			return -1;
-		}
-
-		if (args->verbose == f_VERBOSE)
-			fprintf(stderr, "%8llx: %s: trunc size '%llx' (done)\n",
-				(long long)offset, full_name, (long long)st.st_size);
+	if (__ffs_entry_truncate(ffs, full_name,
+				 st.st_size) < 0) {
+		ERRNO(errno);
+		return -1;
 	}
+
+	if (args->verbose == f_VERBOSE)
+		fprintf(stderr, "%8llx: %s: trunc size '%llx' (done)\n",
+			(long long)offset, full_name, (long long)st.st_size);
 
 	if (entry_list_exists(done_list, &entry) == 1) {
 		if (args->verbose == f_VERBOSE)


### PR DESCRIPTION
The actual size of the partitions is not set correctly when we run
op-build to create a PNOR image. entry.actual is set to entry.size
(allocated size) by fpart while creating the partition (truncate
operation), but it is not updated when a LID file is written to the
partition. That causes an error in skiboot while loading CAPP partition,
which has ECC.

With the trusted boot patches recently merged into skiboot, the CAPP
partition fails to be loaded. Skiboot correctly removes the ECC from the
CAPP partition content that comes from the CAPP LID, but it fails when
it reaches the 0xFF byte chain that comes from the partition creation
process. This issue happens because entry.actual is not set properly.

This patch fixes the actual size of the partitions of a PNOR image
created by running op-build. It updates the partition actual size
whenever a given content is about to be written to a PNOR partition.

Signed-off-by: Claudio Carvalho cclaudio@linux.vnet.ibm.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/ffs/13)

<!-- Reviewable:end -->
